### PR TITLE
fix: use version

### DIFF
--- a/.github/workflows/on-pull-merge.yml
+++ b/.github/workflows/on-pull-merge.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cherry Picker
-        uses: evolv-ai/github-actions/cherry-picker@newVersion
+        uses: evolv-ai/github-actions/cherry-picker@v6
         id: cherry-picker
         with:
           token: "${{ secrets.GH_TOKEN }}"


### PR DESCRIPTION
New version of cherry picker allows for activation through comment, and supplies a diff of the new tag vs the previous tag.