### PR TITLE
fix: IE does not supoort template strings

### DIFF
--- a/src/modes/qa.mode.js
+++ b/src/modes/qa.mode.js
@@ -1,5 +1,6 @@
 export const QA_RE = 'evolvCandidateToken=(([0-9]+)_([0-9]+)_([0-9a-z]+))';
-const QA_RE_REPLACE = `#?&?${QA_RE}`;
+// template strings is not supported by IE
+const QA_RE_REPLACE = '#?&?' + QA_RE;
 
 export default {
 	shouldActivate(environmentId) {


### PR DESCRIPTION
RKT-7588

The problem is that ES6 template strings is not supported by IE. I've just changed it to simple string concatenation.
Please let me know if it would be better to add babel transpilation from ES6 to ES5 to rollup configuration.