### PR TITLE
chore: update timeout to 60s

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import all from './all.js';
 import { MiniPromise } from "@evolv/javascript-sdk";
 
 const MAX_TIMEOUT = 100;
-const THRESHOLD = 1000;
+const THRESHOLD = 60000;
 
 
 function main(client) {


### PR DESCRIPTION
timeout of 1s is causing experiments to timeout if asset.js is slightly late. Make much larger whilst better fix is constructed

RKT-7747