### PR TITLE
feat: use master during dev, use published in releasses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -177,9 +177,8 @@
       "optional": true
     },
     "@evolv/javascript-sdk": {
-      "version": "1.2.10-alpha-102813c",
-      "resolved": "https://registry.npmjs.org/@evolv/javascript-sdk/-/javascript-sdk-1.2.10-alpha-102813c.tgz",
-      "integrity": "sha512-OtYbXC9t+ZJ1FRRYxhQbahu8RviUrwYt8wCJ4tB2lB39CVY7DfauzX/ef4DNdovxGy/kQI2AaT1K6GTiqADfqQ==",
+      "version": "git://github.com/evolv-ai/javascript-sdk.git#d772ee209df879b8d00afdae3b2c289794d8dcda",
+      "from": "git://github.com/evolv-ai/javascript-sdk.git",
       "requires": {
         "base64-arraybuffer": "^0.2.0",
         "deepmerge": "^4.2.2"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "Frazer Bayley",
   "license": "Apache-2.0",
   "dependencies": {
-    "@evolv/javascript-sdk": "^1.2.10-alpha-102813c"
+    "@evolv/javascript-sdk": "git://github.com/evolv-ai/javascript-sdk.git"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.2",


### PR DESCRIPTION
Proposal: We point the asset manager at master branch of the js-sdk while its on master. But we point it at a specific npm version when its time to create the asset manager for the release.