### PR TITLE
fix: only load one snippet

### DIFF
--- a/src/tests/webloader.test.js
+++ b/src/tests/webloader.test.js
@@ -93,14 +93,8 @@ describe('the web loader', () => {
 	it('should only initialize one webloader', async () => {
 		setupGlobal(null);
 
-		webloader = await import('../webloader.js');
-
-		try {
-			var webloader2 = await import('../webloader.js?cachebust=true');
-			assert.strictEqual(1,2, 'An error should be thrown before hitting this line');
-		} catch(e) {
-			assert.ok(true, 'An error is expected');
-		}
+		webloader = await import('../webloader.js')
+		var webloader2 = await import('../webloader.js?cachebust=true');
 
 		const scripts = document.getElementsByTagName('script');
 		const links = document.getElementsByTagName('link');

--- a/src/tests/webloader.test.js
+++ b/src/tests/webloader.test.js
@@ -90,6 +90,35 @@ describe('the web loader', () => {
 		assert.strictEqual(window.evolv, undefined,'The evolv object should not have been exposed');
 	});
 
+	it('should only initialize one webloader', async () => {
+		setupGlobal(null);
+
+		webloader = await import('../webloader.js');
+
+		try {
+			var webloader2 = await import('../webloader.js?cachebust=true');
+			assert.strictEqual(1,2, 'An error should be thrown before hitting this line');
+		} catch(e) {
+			assert.ok(true, 'An error is expected');
+		}
+
+		const scripts = document.getElementsByTagName('script');
+		const links = document.getElementsByTagName('link');
+		assert.equal(scripts.length, 1, 'One script should have been added');
+		assert.equal(links.length, 1, 'One stylesheet should have been added');
+		assert.ok(window.localStorage.values['evolv:uid'], 'The user id should have been generated and stored');
+		assert.ok(window.sessionStorage.values['evolv:sid'], 'The session id should have been generated and stored');
+		assert.ok(window.evolv.context, 'The evolv context should have been exposed');
+		assert.ok(window.evolv.client, 'The evolv client should have been exposed');
+		assert.ok(window.evolv.assetManager, 'The evolv assetManager should have been exposed');
+		assert.equal(
+			window.evolv.context.uid, window.localStorage.values['evolv:uid'],
+			'The evolv context should have been initialized with the same uid as stored');
+		assert.equal(
+			window.evolv.context.sid, window.sessionStorage.values['evolv:sid'],
+			'The evolv context should have been initialized with the same sid as stored');
+	});
+
 	it('should initialize with cookies configured and domain defined', async () => {
 		setupGlobal(null, "*.example.com");
 

--- a/src/webloader.js
+++ b/src/webloader.js
@@ -102,13 +102,20 @@ function checkInstanceCount(evolv) {
 	}
 
 	if (evolv.instancesCount > 1) {
-		throw new Error('Multiple Evolv instances - please verify you have only loaded Evolv once');
+		console.warn('Multiple Evolv instances - please verify you have only loaded Evolv once');
+
+		return true;
 	}
 }
 
 function main() {
 	window.evolv = window.evolv || {};
 	const evolv = window.evolv;
+
+	if (checkInstanceCount(evolv)) {
+		return;
+	}
+
 	const script = currentScript();
 
 	if (!evolv.store) {
@@ -129,8 +136,6 @@ function main() {
 			return (session ? window.sessionStorage : window.localStorage).getItem('evolv:' + key);
 		}
 	}
-
-	checkInstanceCount(evolv);
 
 	modes.forEach(function(mode) {
 		return mode.shouldActivate(script.dataset.evolvEnvironment) && mode.activate();

--- a/src/webloader.js
+++ b/src/webloader.js
@@ -84,6 +84,28 @@ function handlePushState(client) {
 	window.addEventListener('stateupdate_evolv', updateContext);
 }
 
+function checkInstanceCount(evolv) {
+	if (!evolv.instancesCount) {
+		evolv.instancesCount = 1;
+	} else {
+		evolv.instancesCount++;
+	}
+
+	// Not works for IE, but it needs only in web-editor (chrome)
+	if (window.CustomEvent) {
+		try {
+			const webloaderLoadEvent = new CustomEvent('webloader-loaded', {'detail': 	evolv.instancesCount });
+			document.dispatchEvent(webloaderLoadEvent);
+		} catch(e) {
+			console.warn('Evolv: Could not fire custom event')
+		}
+	}
+
+	if (evolv.instancesCount > 1) {
+		throw new Error('Multiple Evolv instances - please verify you have only loaded Evolv once');
+	}
+}
+
 function main() {
 	window.evolv = window.evolv || {};
 	const evolv = window.evolv;
@@ -108,21 +130,7 @@ function main() {
 		}
 	}
 
-	if (!evolv.instancesCount) {
-		window.evolv.instancesCount = 1;
-	} else {
-		evolv.instancesCount++;
-	}
-
-	// Not works for IE, but it needs only in web-editor (chrome)
-	if (window.CustomEvent) {
-		try {
-			const webloaderLoadEvent = new CustomEvent('webloader-loaded', {'detail': window.evolv.instancesCount });
-			document.dispatchEvent(webloaderLoadEvent);
-		} catch(e) {
-			console.warn('Evolv: Could not fire custom event')
-		}
-	}
+	checkInstanceCount(evolv);
 
 	modes.forEach(function(mode) {
 		return mode.shouldActivate(script.dataset.evolvEnvironment) && mode.activate();


### PR DESCRIPTION
throw an error if there is an existing snippet loaded. This allows the existing snippet to run correctly

RKT-8506