### PR TITLE
fix: uid/sid were not persistent once stored

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -1,7 +1,7 @@
 import {getCookie, setCookie} from "./cookies.js";
 
 /**
- * @description Storage manager to ensure no data is persisted if consentis required, and has not been given.
+ * @description Storage manager to ensure no data is persisted if consent is required and has not been given.
  * The persisted value always takes precedence in retrieval
  *
  * @param {string|undefined} useCookies - 'true' for the top level domain, otherwise pass in the subdomain. Leave blank to use

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,6 +1,8 @@
 import {getCookie, setCookie} from "./cookies.js";
 
 /**
+ * @description Storage manager to ensure no data is persisted if consentis required, and has not been given.
+ * The persisted value always takes precedence in retrieval
  *
  * @param {string|undefined} useCookies - 'true' for the top level domain, otherwise pass in the subdomain. Leave blank to use
  * local storage
@@ -33,16 +35,24 @@ function EvolvStorageManager(useCookies, allowPersistence) {
     (session ? window.sessionStorage : window.localStorage).setItem('evolv:' + key, value);
   };
 
+  function retrievePersisted(key, session) {
+    if (useCookies && !session) {
+      return getCookie('evolv:' + key);
+    }
+    return (session ? window.sessionStorage : window.localStorage).getItem('evolv:' + key);
+  }
+
   this.retrieve = function (key, session) {
+    let persistedValue = retrievePersisted(key, session);
+
+    if (persistedValue !== undefined) return persistedValue;
+
     if (!_allowPersistence) {
       let consentStore = getConsentStore(session);
       return consentStore[key] && consentStore[key].value;
     }
 
-    if (useCookies && !session) {
-      return getCookie('evolv:' + key);
-    }
-    return (session ? window.sessionStorage : window.localStorage).getItem('evolv:' + key);
+    return persistedValue;
   };
 
   this.allowPersistentStorage = function() {

--- a/src/tests/storage.test.js
+++ b/src/tests/storage.test.js
@@ -107,4 +107,19 @@ describe('storage checks', ()  => {
     assert.equal(window.document.cookie,  '', 'Not stored in cookie storage');
     assert.equal(window.sessionStorage.getItem('evolv:key2'),  'value2', 'Not stored in session storage');
   });
+
+  it('should retrieve from the persistent store if the data is there', () => {
+    let evolvStorageManager = new EvolvStorageManager(undefined, false);
+
+    window.localStorage.setItem('evolv:key1', 'value1');
+    window.sessionStorage.setItem('evolv:key2', 'value2');
+
+    assert.equal(evolvStorageManager.retrieve('key1', false), 'value1', 'persistent value should be retrieved feom local store');
+    assert.equal(evolvStorageManager.retrieve('key2', true), 'value2', 'persistent value should be retrieved from session store');
+
+    //evolvStorageManager.store('key2', 'value2',  true);
+
+    //evolvStorageManager.allowPersistentStorage();
+
+  });
 });

--- a/src/tests/storage.test.js
+++ b/src/tests/storage.test.js
@@ -116,10 +116,5 @@ describe('storage checks', ()  => {
 
     assert.equal(evolvStorageManager.retrieve('key1', false), 'value1', 'persistent value should be retrieved feom local store');
     assert.equal(evolvStorageManager.retrieve('key2', true), 'value2', 'persistent value should be retrieved from session store');
-
-    //evolvStorageManager.store('key2', 'value2',  true);
-
-    //evolvStorageManager.allowPersistentStorage();
-
   });
 });


### PR DESCRIPTION
Always take the vaalue from the persistent store if it exists.
Without this change, uid and sid and replaced every refresh if the consent attribute is set

RKT-8835