### PR TITLE
fix: change gate check on updateFunctionsToRun()

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -182,7 +182,7 @@ const Runner = /** @class */ (function () {
      * @returns void
      */
     Runner.prototype.updateFunctionsToRun = function (keys) {
-        if (!this.areVariantsDefined()) {
+        if (!this.initialized) {
             this.deferred = keys;
             return;
         }


### PR DESCRIPTION
the script tag onload weirdly fires some time after the script has been parsed and executed. therefore, evolv.javascript.variants can be defined before loadFunctions() is called via the script.onload handler, leading to inconsistent state

[RKT-8750]