### PR TITLE
feat: execute evolv.rerun if multiple instances are found RKT-8984

### DIFF
--- a/src/webloader.js
+++ b/src/webloader.js
@@ -113,6 +113,7 @@ function checkInstanceCount(evolv) {
 
 	if (evolv.instancesCount > 1) {
 		console.warn('Multiple Evolv instances - please verify you have only loaded Evolv once');
+		window.evolv.rerun()
 
 		return true;
 	}


### PR DESCRIPTION
If we call evolv.rerun when multiple instances are detected, any relevant JS will execute. At the moment, nothing executes if multiple instances are found. This is a major problem for Bouygues.

Is this the right way to go about it? I've tested and it works for Bouygues.