### PR TITLE
fix: Fallback to generated UID if GA client Id is not available AP-185

### DIFF
--- a/src/integrations/ga.js
+++ b/src/integrations/ga.js
@@ -1,9 +1,15 @@
+import { generate } from '../guids.js';
+
 let pollAttempt = 0;
 const maxPollAttempts = 60;
 
 function gaIntegration() {
     if (pollAttempt > maxPollAttempts) {
-        console.log('Evolv: unable to set uid');
+        console.warn('Evolv: GA clientId not found, using generated UID');
+        const id = generate();
+
+        window.evolv.setUid(id);
+        window.evolv.client.emit('evolv-uid.generated');
         return;
     }
 
@@ -31,7 +37,7 @@ function setUidFromGaCid() {
 }
 
 function isValidGaClientId(cid) {
-    return /^\d+\.\d+$/.test(cid);
+    return /^\d+[.|_]\d+$/.test(cid);
 }
 
 export { gaIntegration, isValidGaClientId };


### PR DESCRIPTION
Ticket: AP-185

Fallback to using Evolv-generated UID if GA client Id is not available.