### PR TITLE
fix: fallback generated uid should persist

### DIFF
--- a/src/integrations/ga.js
+++ b/src/integrations/ga.js
@@ -1,14 +1,11 @@
-import { generate } from '../guids.js';
-
 let pollAttempt = 0;
 const maxPollAttempts = 60;
 
 function gaIntegration() {
     if (pollAttempt > maxPollAttempts) {
         console.warn('Evolv: GA clientId not found, using generated UID');
-        const id = generate();
 
-        window.evolv.setUid(id);
+        window.evolv.generateUid();
         window.evolv.client.emit('evolv-uid.generated');
         return;
     }

--- a/src/webloader.js
+++ b/src/webloader.js
@@ -147,6 +147,13 @@ function main() {
     main();
   };
 
+	evolv.generateUid = function generateUid() {
+		if (script.dataset.evolvLazyUid) {
+			delete script.dataset.evolvLazyUid;
+		}
+		main();
+	};
+
 	// If evolvLazyUid is true and no uid is set - get GA client Id and set uid
 	if (checkLazyUid(script)) {
 		// Temporary hotfix for GA Client Id integration


### PR DESCRIPTION
AP-185

Fix: currently, with the fallback UID added if the page is refreshed a new UID is generated. This PR simplifies the process to just running `main()` without the `data-evolv-lazy-uid` attribute, which will behave the same as if a UID is not passed. We generate the UID and store it for when the page refreshes or the user returns.