### PR TITLE
fix: if UID exists in localStorage, use it and ignore lazy-uid attribute

### DIFF
--- a/src/tests/webloader.test.js
+++ b/src/tests/webloader.test.js
@@ -217,6 +217,24 @@ describe('the web loader', () => {
 		mathRoundStub.restore();
 	});
 
+	it('should use UID from local storage instead if one exists and ignore lazy-uid', async () => {
+		setupGlobal(null, undefined, { evolvLazyUid: 'true' });
+
+		const MOCK_GENERATE_UID = `123_456`;
+
+		let localStub = sinon.stub(global.window.localStorage, 'getItem').returns(MOCK_GENERATE_UID);
+
+		webloader = await import(`../webloader.js?lazy=${Math.random()}`);
+
+		let scripts = document.getElementsByTagName('script');
+		let links = document.getElementsByTagName('link');
+		assert.equal(scripts.length, 1, 'The script should have been added');
+		assert.equal(links.length, 1, 'The stylesheet should have been added');
+		assert.ok(scripts[0].src.indexOf(MOCK_GENERATE_UID) > -1, 'The uid should match the uid from localStorage.');
+
+		localStub.restore();
+	});
+
 	describe('consent checks', ()  => {
     it('should initialize properly', async () => {
       setupGlobal(null, undefined, { evolvRequireConsent: 'true' });

--- a/src/webloader.js
+++ b/src/webloader.js
@@ -119,7 +119,8 @@ function checkInstanceCount(evolv) {
 }
 
 function checkLazyUid(script) {
-	if (script.dataset.evolvLazyUid) {
+	const existingUid = window.localStorage.getItem('evolv:uid');
+	if (script.dataset.evolvLazyUid && !existingUid) {
 		if (!script.dataset.evolvUid || !isValidGaClientId(script.dataset.evolvUid)) {
 			return true;
 		}


### PR DESCRIPTION
AP-185
When falling back to a generated UID, we want to prevent the user from getting a new UID when revisiting and the UID does not fall back.

Added a check to see if `evolv:uid` exists in localStorage, and if one exists, ignore `data-evolv-lazy-uid` and continue as normal.
If the UID does not exist in localStorage and `data-evolv-lazy-uid` attribute is present, the normal lazy uid flow would happen.