### PR TITLE
fix: block and qa modes don't work when consent required

### DIFF
--- a/src/modes/block.mode.js
+++ b/src/modes/block.mode.js
@@ -12,7 +12,7 @@ export default {
     const regex = new RegExp(BLOCK_RE);
     const match = window.location.hash.match(regex) || window.location.search.match(regex);
     if (match) {
-      window.evolv.store('blockExecution', match[1], true);
+      window.sessionStorage.setItem('evolv:blockExecution', match[1]);
       window.location.href = window.location.href.replace(new RegExp(BLOCK_RE_REPLACE), '');
     }
   }

--- a/src/modes/qa.mode.js
+++ b/src/modes/qa.mode.js
@@ -3,18 +3,18 @@ export const QA_RE = 'evolvCandidateToken=(([0-9]+)_([0-9]+)_([0-9a-z]+))';
 const QA_RE_REPLACE = '#?&?' + QA_RE;
 
 export default {
-	shouldActivate: function(environmentId) {
-		const match = window.location.hash.match(new RegExp(QA_RE));
-		return match && environmentId === match[4];
-	},
-	activate: function() {
-		const match = window.location.hash.match(new RegExp(QA_RE));
+  shouldActivate: function(environmentId) {
+    const match = window.location.hash.match(new RegExp(QA_RE));
+    return match && environmentId === match[4];
+  },
+  activate: function() {
+    const match = window.location.hash.match(new RegExp(QA_RE));
 
-		if (match) {
-			const token = match[1];
+    if (match) {
+      const token = match[1];
 
-			window.evolv.store('candidateToken', token, true);
-			window.location.href = window.location.href.replace(new RegExp(QA_RE_REPLACE), '');
-		}
-	}
+      window.sessionStorage.setItem('evolv:candidateToken', token);
+      window.location.href = window.location.href.replace(new RegExp(QA_RE_REPLACE), '');
+    }
+  }
 };

--- a/src/webloader.js
+++ b/src/webloader.js
@@ -177,12 +177,12 @@ function main() {
 		return mode.shouldActivate(script.dataset.evolvEnvironment) && mode.activate();
 	});
 
-  const blockExecution = evolv.retrieve('blockExecution', true);
-  if (blockExecution == 'true') {
+  const blockExecution = window.sessionStorage.getItem('evolv:blockExecution');
+  if (blockExecution === 'true') {
     return;
   }
 
-	const candidateToken = evolv.retrieve('candidateToken', true);
+  const candidateToken = window.sessionStorage.getItem('evolv:candidateToken');
 	const env = candidateToken || script.dataset.evolvEnvironment;
 
 	const version = 1;


### PR DESCRIPTION
[AP-138](https://evolv-ai.atlassian.net/browse/AP-138)

The `evolvBlockExecution` and `evolvCandidateToken` don’t work in case when `data-evolv-require-consent="true"` is present on webloader.js snippet.