### PR TITLE
feat: env id in queryparams

### DIFF
--- a/src/tests/build-config.test.js
+++ b/src/tests/build-config.test.js
@@ -4,7 +4,7 @@ import jsdom from './mocks/jsdom.js';
 import { buildConfig } from '../build-config.js';
 
 
-describe.only('buildConfig()', () => {
+describe('buildConfig()', () => {
 	let cleanup;
 
 	beforeEach(() => {

--- a/src/webloader.js
+++ b/src/webloader.js
@@ -7,7 +7,21 @@ import { buildConfig } from './build-config.js';
  * @return {boolean}
  */
 function isEvolvScript(script) {
-	return script && script.dataset && 'evolvEnvironment' in script.dataset;
+	return script && (script.dataset && 'evolvEnvironment' in script.dataset
+		|| hasEnvironmentInQueryParam(script));
+}
+
+function hasEnvironmentInQueryParam(script) {
+	const regex = /[?&]environment=([^&]+)/;
+	let matches = script.src.match(regex);
+
+	return (matches && matches.length) ? matches[1] : false;
+}
+
+function ensureEnvironmentOnDataset(script) {
+	script.dataset.evolvEnvironment = script.dataset.evolvEnvironment || hasEnvironmentInQueryParam(script);
+
+	return script.dataset;
 }
 
 /**
@@ -31,7 +45,8 @@ function currentScript() {
 // If the user has requested not to be tracked, or the browser is older than ie11, bail out.
 if ((!navigator.doNotTrack || navigator.doNotTrack === 'unspecified' || navigator.doNotTrack === '0') && typeof Map !== 'undefined') {
 	const script = currentScript();
-	const config = buildConfig(script.dataset);
+	const dataset =  ensureEnvironmentOnDataset(script);
+	const config = buildConfig(dataset);
 
 	bootstrap(config);
 }


### PR DESCRIPTION
Option to set environment through query parameter -- added as integration doesn't allow data attibutes. We should still use data attributes as the primary method

AP-622