### PR TITLE
ci: restrict set of files included in package bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
   ],
   "author": "Frazer Bayley",
   "license": "Apache-2.0",
+	"files": [
+		"dist/**/*",
+		"docs/**/*",
+		"src/**/*"
+	],
   "dependencies": {
     "@evolv/client": "2.0.0-alpha-92f8489"
   },


### PR DESCRIPTION
the bundle currently includes most of the files in the repo including e2e tests and deployment scripts