### PR TITLE
feat(AP-1869): bump version of @evolv/client

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16.14.2'
       - name: Checkout Ref
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/on-deployment.yml
+++ b/.github/workflows/on-deployment.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16.14.2'
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/on-pull.yml
+++ b/.github/workflows/on-pull.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16.14.2'
       - name: Checkout Ref
         uses: actions/checkout@v1
         # ref is not set as it should be using master only

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16.14.2'
       - name: Checkout Ref
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/scheduled-deployment.yml
+++ b/.github/workflows/scheduled-deployment.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16.14.2'
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@evolv/client": "2.0.1-alpha-10e1518"
+        "@evolv/client": "2.1.6-alpha-6b05abe"
       },
       "devDependencies": {
         "cz-conventional-changelog": "^3.1.0",
@@ -1175,7 +1175,8 @@
     "node_modules/@evolv/hashing": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@evolv/hashing/-/hashing-1.1.0.tgz",
-      "integrity": "sha512-PhqiRNwX+0hxl1Y94ytmDVMbqeG3l2JMJ1Ip4BznQr7cGd36YIfl4glb+W9lgaN/p22+TAhCapzUFfIlpVOGbw=="
+      "integrity": "sha512-PhqiRNwX+0hxl1Y94ytmDVMbqeG3l2JMJ1Ip4BznQr7cGd36YIfl4glb+W9lgaN/p22+TAhCapzUFfIlpVOGbw==",
+      "peer": true
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -2442,16 +2443,16 @@
       "dev": true
     },
     "node_modules/@evolv/client": {
-      "version": "2.0.1-alpha-10e1518",
-      "resolved": "https://registry.npmjs.org/@evolv/client/-/client-2.0.1-alpha-10e1518.tgz",
-      "integrity": "sha512-7NEiGbvG3hbHeppQ7N2pQKamVjjNZYn7GFu5Nw7BKPgTgip1JlTgpJXL69fnyJNQ5yrGGiNLW12dJ30hwnCRLQ==",
-      "dependencies": {
-        "@evolv/hashing": "^1.1.0",
-        "base64-arraybuffer": "^0.2.0",
-        "deepmerge": "^4.2.2"
-      },
+      "version": "2.1.6-alpha-6b05abe",
+      "resolved": "https://registry.npmjs.org/@evolv/client/-/client-2.1.6-alpha-6b05abe.tgz",
+      "integrity": "sha512-2MOy55t6tDha/0PELHQpM/cdiYfBFmt6mUuAyNLLtc3VivGU4UST2zs1fMvsmSmOTkYgLPjl65lJXAB9+wsyTQ==",
       "engines": {
         "node": ">=13"
+      },
+      "peerDependencies": {
+        "@evolv/hashing": "^1.1.0",
+        "base64-arraybuffer": ">=0.2.0",
+        "deepmerge": "^4.2.2"
       }
     },
     "node_modules/number-is-nan": {
@@ -7230,6 +7231,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
       "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -19469,19 +19471,15 @@
       }
     },
     "@evolv/client": {
-      "version": "2.0.1-alpha-10e1518",
-      "resolved": "https://registry.npmjs.org/@evolv/client/-/client-2.0.1-alpha-10e1518.tgz",
-      "integrity": "sha512-7NEiGbvG3hbHeppQ7N2pQKamVjjNZYn7GFu5Nw7BKPgTgip1JlTgpJXL69fnyJNQ5yrGGiNLW12dJ30hwnCRLQ==",
-      "requires": {
-        "@evolv/hashing": "^1.1.0",
-        "base64-arraybuffer": "^0.2.0",
-        "deepmerge": "^4.2.2"
-      }
+      "version": "2.1.6-alpha-6b05abe",
+      "resolved": "https://registry.npmjs.org/@evolv/client/-/client-2.1.6-alpha-6b05abe.tgz",
+      "integrity": "sha512-2MOy55t6tDha/0PELHQpM/cdiYfBFmt6mUuAyNLLtc3VivGU4UST2zs1fMvsmSmOTkYgLPjl65lJXAB9+wsyTQ=="
     },
     "@evolv/hashing": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@evolv/hashing/-/hashing-1.1.0.tgz",
-      "integrity": "sha512-PhqiRNwX+0hxl1Y94ytmDVMbqeG3l2JMJ1Ip4BznQr7cGd36YIfl4glb+W9lgaN/p22+TAhCapzUFfIlpVOGbw=="
+      "integrity": "sha512-PhqiRNwX+0hxl1Y94ytmDVMbqeG3l2JMJ1Ip4BznQr7cGd36YIfl4glb+W9lgaN/p22+TAhCapzUFfIlpVOGbw==",
+      "peer": true
     },
     "@evolv/mutate": {
       "version": "1.5.4",
@@ -20628,7 +20626,8 @@
     "base64-arraybuffer": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "peer": true
     },
     "base64-js": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"src/**/*"
 	],
   "dependencies": {
-    "@evolv/client": "2.0.1-alpha-10e1518"
+    "@evolv/client": "2.1.6-alpha-6b05abe"
   },
   "optionalDependencies": {
     "@evolv/mutate": "^1.5.4"


### PR DESCRIPTION
the major difference is that this version uses differential builds (one for node, one for browser)