### PR TITLE
feat(AP-1917): Removing client-side DNT support

### DIFF
--- a/src/tests/webloader.test.js
+++ b/src/tests/webloader.test.js
@@ -58,39 +58,6 @@ describe('the web loader', () => {
 			'The evolv context should have been initialized with the same uid as stored');
 	});
 
-	it('should initialize with firefox DNT setup', async () => {
-		setupGlobal('unspecified');
-
-		webloader = await import(`../webloader-lite.js?foo=${Math.random()}`);
-		const scripts = global.document.getElementsByTagName('script');
-		const links = global.document.getElementsByTagName('link');
-		assert.equal(scripts.length, 1, 'The script should have been added');
-		assert.equal(links.length, 1, 'The stylesheet should have been added');
-		assert.ok(global.window.evolv, 'The evolv object should have been exposed');
-	});
-
-	it('should initialize with \'0\' DNT setup', async () => {
-		setupGlobal('0');
-
-		webloader = await import(`../webloader-lite.js?foo=${Math.random()}`);
-
-		const scripts = document.getElementsByTagName('script');
-		const links = document.getElementsByTagName('link');
-		assert.equal(scripts.length, 1, 'The script should have been added');
-		assert.equal(links.length, 1, 'The stylesheet should have been added');
-		assert.ok(window.evolv, 'The evolv object should have been exposed');
-	});
-
-	it('should not initialize with DNT true', async () => {
-		setupGlobal('1');
-		webloader = await import(`../webloader-lite.js?foo=${Math.random()}`);
-		const scripts = document.getElementsByTagName('script');
-		const links = document.getElementsByTagName('link');
-		assert.equal(scripts.length, 0, 'The script should not have been added');
-		assert.equal(links.length, 0, 'The stylesheet should not have been added');
-		assert.strictEqual(window.evolv, undefined, 'The evolv object should not have been exposed');
-	});
-
 	it('should only initialize one webloader', async () => {
 		setupGlobal(null);
 

--- a/src/webloader.js
+++ b/src/webloader.js
@@ -43,16 +43,18 @@ function currentScript() {
 }
 
 export function initialize(callback) {
-	// If the user has requested not to be tracked, or the browser is older than ie11, bail out.
-	if ((!navigator.doNotTrack || navigator.doNotTrack === 'unspecified' || navigator.doNotTrack === '0') && typeof Map !== 'undefined') {
-		const script = currentScript();
-		const dataset =  ensureEnvironmentOnDataset(script);
-		const config = buildConfig(dataset);
+	// If the browser is older than ie11, bail out.
+	if (typeof Map === 'undefined') {
+		return;
+	}
 
-		bootstrap(config);
+	const script = currentScript();
+	const dataset =  ensureEnvironmentOnDataset(script);
+	const config = buildConfig(dataset);
 
-		if (callback) {
-			callback(config);
-		}
+	bootstrap(config);
+
+	if (callback) {
+		callback(config);
 	}
 }


### PR DESCRIPTION
This PR removes the dnt check client-side as it is a fully deprecated standard and not supported by most products. We can consider implementing it server-side, but client-side enforcement breaks feature flagging and personalization usecases.