### PR TITLE
Handle redirect variants

### DIFF
--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -102,11 +102,7 @@ function main(container, _runner) {
 						// Checking that url where we want to redirect the user is not the same as current url
 						if((isPartialPath && window.location.pathname !== v.target_url) || (!isPartialPath && window.location.origin + window.location.pathname !== v.target_url)){
 							const params = v.include_query_parameters ? window.location.search : '';
-							let path = (v.target_url.startsWith('http') ? '' : 'https://') + v.target_url + params;
-							if(isPartialPath){
-								path = v.target_url + params;
-							}
-							window.location = path
+							window.location = v.target_url + params
 							redirectionInProgress = true;
 						}
 					})

--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -96,6 +96,7 @@ function main(container, _runner) {
 					}
 					// Target url can be a partial path, like '/products'. We should process it by adding it to the location.origin
 					const isPartialPath = v.target_url.startsWith('/');
+					// Checking that url where we want to redirect the user is not the same as current url
 					if((isPartialPath && window.location.pathname !== v.target_url) || (!isPartialPath && window.location.origin + window.location.pathname !== v.target_url)){
 						const params = v.include_query_parameters ? window.location.search : '';
 						let path = (v.target_url.startsWith('http') ? '' : 'https://') + v.target_url + params;

--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -103,10 +103,8 @@ function main(container, _runner) {
 						if(isPartialPath){
 							path = window.location.origin + v.target_url + params;
 						}
-						if(window.confirm("Are you sure you want to process redirect to " + path + "?")){
-							window.location = path
-							redirectionInProgress = true;
-						}
+						window.location = path
+						redirectionInProgress = true;
 					}
 				});
 			});

--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -62,9 +62,8 @@ function main(container, _runner) {
 	let hasRunRedirect = false
 	let redirectionInProgress = false
 
-	client.getActiveKeys('').listen(function (keys) {
+	client.getActiveKeys('web').listen(function (keys) {
 		const liveContexts = keys.current
-			.filter(function(key) { return key.startsWith('web') })
 			.map(toUnderscoreKey)
 			.sort(function (a, b) {
 				return a.length - b.length;
@@ -86,8 +85,7 @@ function main(container, _runner) {
 		} else if (cssAsset) {
 			confirm();
 		}
-
-		runRedirectVariants(keys)
+		runRedirectVariants(keys);
 	});
 
 	function runRedirectVariants(keys){

--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -59,8 +59,11 @@ function main(container, _runner) {
 		client.reevaluateContext();
 	};
 
-	client.getActiveKeys('web').listen(function (keys) {
+	let hasRunRedirect = false
+
+	client.getActiveKeys('').listen(function (keys) {
 		const liveContexts = keys.current
+			.filter(function(key) { return key.startsWith('web') })
 			.map(toUnderscoreKey)
 			.sort(function (a, b) {
 				return a.length - b.length;
@@ -82,11 +85,7 @@ function main(container, _runner) {
 		} else if (cssAsset) {
 			confirm();
 		}
-	});
 
-	let hasRunRedirect = false
-
-	client.getActiveKeys().listen(function (keys) {
 		let redirectionInProgress = false;
 		if(!hasRunRedirect){
 			hasRunRedirect = true

--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -96,19 +96,20 @@ function main(container, _runner) {
 					if (redirectionInProgress || v.type !== 'redirect' || !v.target_url) {
 						return;
 					}
-					confirm();
-					// Target url can be a partial path, like '/products'. We should process it by adding it to the location.origin
-					const isPartialPath = v.target_url.startsWith('/');
-					// Checking that url where we want to redirect the user is not the same as current url
-					if((isPartialPath && window.location.pathname !== v.target_url) || (!isPartialPath && window.location.origin + window.location.pathname !== v.target_url)){
-						const params = v.include_query_parameters ? window.location.search : '';
-						let path = (v.target_url.startsWith('http') ? '' : 'https://') + v.target_url + params;
-						if(isPartialPath){
-							path = window.location.origin + v.target_url + params;
+					client.confirm().then(function() {
+						// Target url can be a partial path, like '/products'. We should process it by adding it to the location.origin
+						const isPartialPath = v.target_url.startsWith('/');
+						// Checking that url where we want to redirect the user is not the same as current url
+						if((isPartialPath && window.location.pathname !== v.target_url) || (!isPartialPath && window.location.origin + window.location.pathname !== v.target_url)){
+							const params = v.include_query_parameters ? window.location.search : '';
+							let path = (v.target_url.startsWith('http') ? '' : 'https://') + v.target_url + params;
+							if(isPartialPath){
+								path = window.location.origin + v.target_url + params;
+							}
+							window.location = path
+							redirectionInProgress = true;
 						}
-						window.location = path
-						redirectionInProgress = true;
-					}
+					})
 				});
 			});
 		}

--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -59,8 +59,6 @@ function main(container, _runner) {
 		client.reevaluateContext();
 	};
 
-	let hasRunRedirect = false
-
 	client.getActiveKeys('web').listen(function (keys) {
 		const liveContexts = keys.current
 			.map(toUnderscoreKey)
@@ -84,9 +82,12 @@ function main(container, _runner) {
 		} else if (cssAsset) {
 			confirm();
 		}
+	});
 
+	let hasRunRedirect = false
+
+	client.getActiveKeys().listen(function (keys) {
 		let redirectionInProgress = false;
-
 		if(!hasRunRedirect){
 			hasRunRedirect = true
 			keys.current.forEach(function(key) {
@@ -94,6 +95,7 @@ function main(container, _runner) {
 					if (redirectionInProgress || v.type !== 'redirect' || !v.target_url) {
 						return;
 					}
+					confirm();
 					// Target url can be a partial path, like '/products'. We should process it by adding it to the location.origin
 					const isPartialPath = v.target_url.startsWith('/');
 					// Checking that url where we want to redirect the user is not the same as current url

--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -60,6 +60,7 @@ function main(container, _runner) {
 	};
 
 	let hasRunRedirect = false
+	let redirectionInProgress = false
 
 	client.getActiveKeys('').listen(function (keys) {
 		const liveContexts = keys.current
@@ -86,7 +87,10 @@ function main(container, _runner) {
 			confirm();
 		}
 
-		let redirectionInProgress = false;
+		runRedirectVariants(keys)
+	});
+
+	function runRedirectVariants(keys){
 		if(!hasRunRedirect){
 			hasRunRedirect = true
 			keys.current.forEach(function(key) {
@@ -110,7 +114,7 @@ function main(container, _runner) {
 				});
 			});
 		}
-	});
+	}
 }
 
 /**

--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -104,7 +104,7 @@ function main(container, _runner) {
 							const params = v.include_query_parameters ? window.location.search : '';
 							let path = (v.target_url.startsWith('http') ? '' : 'https://') + v.target_url + params;
 							if(isPartialPath){
-								path = window.location.origin + v.target_url + params;
+								path = v.target_url + params;
 							}
 							window.location = path
 							redirectionInProgress = true;

--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -98,11 +98,12 @@ function main(container, _runner) {
 					}
 					client.confirm().then(function() {
 						// Target url can be a partial path, like '/products'. We should process it by adding it to the location.origin
-						const isPartialPath = v.target_url.startsWith('/');
+						const params = v.include_query_parameters ? window.location.search : '';
+						const path = v.target_url + params;
+						const newUrl = new URL(path, window.location.href);
 						// Checking that url where we want to redirect the user is not the same as current url
-						if((isPartialPath && window.location.pathname !== v.target_url) || (!isPartialPath && window.location.origin + window.location.pathname !== v.target_url)){
-							const params = v.include_query_parameters ? window.location.search : '';
-							window.location = v.target_url + params;
+						if(newUrl.href !== window.location.href){
+							window.location = path;
 							redirectionInProgress = true;
 						}
 					})

--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -102,7 +102,7 @@ function main(container, _runner) {
 						// Checking that url where we want to redirect the user is not the same as current url
 						if((isPartialPath && window.location.pathname !== v.target_url) || (!isPartialPath && window.location.origin + window.location.pathname !== v.target_url)){
 							const params = v.include_query_parameters ? window.location.search : '';
-							window.location = v.target_url + params
+							window.location = v.target_url + params;
 							redirectionInProgress = true;
 						}
 					})

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -830,16 +830,6 @@ describe('asset manager handles correctly', () => {
 			assert.equal(window.location, 'https://google.com')
 		});
 
-		it('should handle 2 redirects and transfer user to the first url',async () => {
-			keys = ['web.page1.redirectToGoogle', 'web.page1.redirectToEvolv'];
-			global.window = { location: { href: 'https://test-site.com' }, evolv: {}};
-			global.document = new DocumentMock();
-			const client = new EvolvMock(keys);
-			new EvolvAssetManager(client, undefined, mockTiming());
-			await wait(0);
-			assert.equal(window.location, 'https://google.com')
-		});
-
 		it('shouldn\'t redirect if no redirect variants ',async () => {
 			keys = ['web.page1', 'web.page1.variable1'];
 			global.window = { location: { href: 'https://test-site.com' }, evolv: {}};

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -819,7 +819,7 @@ describe('asset manager handles correctly', () => {
 		afterEach(function() {
 			global.window = origWindow;
 		});
-
+		// For the keys info, please refer to keysDict in evolv.mock.js
 		let keys = ['web.page1.redirectToGoogle'];
 		it('should redirect to google.com',async () => {
 			global.window = { location: { href: 'https://test-site.com' }, evolv: {}, confirm: () => true};

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -842,32 +842,33 @@ describe('asset manager handles correctly', () => {
 
 		it('should handle partial path and  redirect to /goods',async () => {
 			keys = ['web.page1.redirectPartialPath'];
-			global.window = { location: { href: 'https://test-site.com', origin : 'https://test-site.com' }};
+			global.window = { myLocation: '', set location(href){this.myLocation = this.location.href + href}, get location(){return { href: 'https://test-site.com', origin : 'https://test-site.com' }}};
 			global.document = new DocumentMock();
 			const client = new EvolvMock(keys);
 			new EvolvAssetManager(client, undefined, mockTiming());
 			await wait(0);
-			assert.equal(window.location, 'https://test-site.com/goods')
+			assert.equal(window.myLocation, 'https://test-site.com/goods')
 		});
 
 		it('should handle partial path with params and redirect to /goods?qwerty=123',async () => {
 			keys = ['web.page1.redirectPartialPathWithParams'];
-			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com', search: '?qwerty=123' }, evolv: {}};
+			// global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com', search: '?qwerty=123' }, evolv: {}};
+			global.window = { myLocation: '', set location(href){this.myLocation = this.location.href + href }, get location(){return { href: 'https://test-site.com', origin : 'https://test-site.com', search: '?qwerty=123'}}};
 			global.document = new DocumentMock();
 			const client = new EvolvMock(keys);
 			new EvolvAssetManager(client, undefined, mockTiming());
 			await wait(0);
-			assert.equal(window.location, 'https://test-site.com/goods?qwerty=123')
+			assert.equal(window.myLocation, 'https://test-site.com/goods?qwerty=123')
 		});
 
 		it('should handle redirect with params and redirect to /evolv.ai/?qwerty=123',async () => {
 			keys = ['web.page1.redirectWithParams'];
-			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com/', search: '?qwerty=123' }, evolv: {}};
+			global.window = { myLocation: '', set location(href){this.myLocation = href }, get location(){return { href: 'https://test-site.com', origin : 'https://test-site.com', search: '?qwerty=123'}}};
 			global.document = new DocumentMock();
 			const client = new EvolvMock(keys);
 			new EvolvAssetManager(client, undefined, mockTiming());
 			await wait(0);
-			assert.equal(window.location, 'https://evolv.ai/?qwerty=123')
+			assert.equal(window.myLocation, 'https://evolv.ai/?qwerty=123')
 		});
 
 		it('should handle redirect to http website',async () => {
@@ -878,16 +879,6 @@ describe('asset manager handles correctly', () => {
 			new EvolvAssetManager(client, undefined, mockTiming());
 			await wait(0);
 			assert.equal(window.location, 'http://info.cern.ch/')
-		});
-
-		it('should handle redirect to \'google.com\'',async () => {
-			keys = ['web.page1.redirectGoogleWithoutHttp'];
-			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com/', search: '?qwerty=123' }, evolv: {}};
-			global.document = new DocumentMock();
-			const client = new EvolvMock(keys);
-			new EvolvAssetManager(client, undefined, mockTiming());
-			await wait(0);
-			assert.equal(window.location, 'https://google.com')
 		});
 	});
 });

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -879,5 +879,25 @@ describe('asset manager handles correctly', () => {
 			await wait(0);
 			assert.equal(window.location, 'https://evolv.ai/?qwerty=123')
 		});
+
+		it('should handle redirect to http website',async () => {
+			keys = ['web.page1.redirectToHttp'];
+			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com/', search: '?qwerty=123' }, evolv: {}};
+			global.document = new DocumentMock();
+			const client = new EvolvMock(keys);
+			new EvolvAssetManager(client, undefined, mockTiming());
+			await wait(0);
+			assert.equal(window.location, 'http://info.cern.ch/')
+		});
+
+		it.only('should handle redirect to \'google.com\'',async () => {
+			keys = ['web.page1.redirectGoogleWithoutHttp'];
+			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com/', search: '?qwerty=123' }, evolv: {}};
+			global.document = new DocumentMock();
+			const client = new EvolvMock(keys);
+			new EvolvAssetManager(client, undefined, mockTiming());
+			await wait(0);
+			assert.equal(window.location, 'https://google.com')
+		});
 	});
 });

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -890,7 +890,7 @@ describe('asset manager handles correctly', () => {
 			assert.equal(window.location, 'http://info.cern.ch/')
 		});
 
-		it.only('should handle redirect to \'google.com\'',async () => {
+		it('should handle redirect to \'google.com\'',async () => {
 			keys = ['web.page1.redirectGoogleWithoutHttp'];
 			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com/', search: '?qwerty=123' }, evolv: {}};
 			global.document = new DocumentMock();

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -5,6 +5,7 @@ import { DocumentMock, StyleSheetMock, ScriptMock } from './mocks/document.mock.
 import EvolvMock from './mocks/evolv.mock.js';
 import wait from './wait.js';
 import sinon from 'sinon';
+import { URL } from 'url';
 
 function mockTiming(offset) {
 	return { timing: { domContentLoadedEventStart: (new Date()).getTime() - offset } };
@@ -824,12 +825,12 @@ describe('asset manager handles correctly', () => {
 		it('should redirect to google.com',async () => {
 			global.window = { location: { href: 'https://test-site.com' }, evolv: {}};
 			global.document = new DocumentMock();
+			global.URL = URL
 			const client = new EvolvMock(keys);
 			new EvolvAssetManager(client, undefined, mockTiming());
 			await wait(0);
 			assert.equal(window.location, 'https://google.com')
 		});
-
 		it('shouldn\'t redirect if no redirect variants ',async () => {
 			keys = ['web.page1', 'web.page1.variable1'];
 			global.window = { location: { href: 'https://test-site.com' }, evolv: {}};

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -822,7 +822,7 @@ describe('asset manager handles correctly', () => {
 		// For the keys info, please refer to keysDict in evolv.mock.js
 		let keys = ['web.page1.redirectToGoogle'];
 		it('should redirect to google.com',async () => {
-			global.window = { location: { href: 'https://test-site.com' }, evolv: {}, confirm: () => true};
+			global.window = { location: { href: 'https://test-site.com' }, evolv: {}};
 			global.document = new DocumentMock();
 			const client = new EvolvMock(keys);
 			new EvolvAssetManager(client, undefined, mockTiming());
@@ -832,7 +832,7 @@ describe('asset manager handles correctly', () => {
 
 		it('should handle 2 redirects and transfer user to the first url',async () => {
 			keys = ['web.page1.redirectToGoogle', 'web.page1.redirectToEvolv'];
-			global.window = { location: { href: 'https://test-site.com' }, evolv: {}, confirm: () => true};
+			global.window = { location: { href: 'https://test-site.com' }, evolv: {}};
 			global.document = new DocumentMock();
 			const client = new EvolvMock(keys);
 			new EvolvAssetManager(client, undefined, mockTiming());
@@ -842,7 +842,7 @@ describe('asset manager handles correctly', () => {
 
 		it('shouldn\'t redirect if no redirect variants ',async () => {
 			keys = ['web.page1', 'web.page1.variable1'];
-			global.window = { location: { href: 'https://test-site.com' }, evolv: {}, confirm: () => true};
+			global.window = { location: { href: 'https://test-site.com' }, evolv: {}};
 			global.document = new DocumentMock();
 			const client = new EvolvMock(keys);
 			new EvolvAssetManager(client, undefined, mockTiming());
@@ -852,7 +852,7 @@ describe('asset manager handles correctly', () => {
 
 		it('should handle partial path and  redirect to /goods',async () => {
 			keys = ['web.page1.redirectPartialPath'];
-			global.window = { location: { href: 'https://test-site.com', origin : 'https://test-site.com' }, evolv: {}, confirm: () => true};
+			global.window = { location: { href: 'https://test-site.com', origin : 'https://test-site.com' }};
 			global.document = new DocumentMock();
 			const client = new EvolvMock(keys);
 			new EvolvAssetManager(client, undefined, mockTiming());
@@ -862,7 +862,7 @@ describe('asset manager handles correctly', () => {
 
 		it('should handle partial path with params and redirect to /goods?qwerty=123',async () => {
 			keys = ['web.page1.redirectPartialPathWithParams'];
-			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com', search: '?qwerty=123' }, evolv: {}, confirm: () => true};
+			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com', search: '?qwerty=123' }, evolv: {}};
 			global.document = new DocumentMock();
 			const client = new EvolvMock(keys);
 			new EvolvAssetManager(client, undefined, mockTiming());
@@ -872,7 +872,7 @@ describe('asset manager handles correctly', () => {
 
 		it('should handle redirect with params and redirect to /evolv.ai/?qwerty=123',async () => {
 			keys = ['web.page1.redirectWithParams'];
-			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com/', search: '?qwerty=123' }, evolv: {}, confirm: () => true};
+			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com/', search: '?qwerty=123' }, evolv: {}};
 			global.document = new DocumentMock();
 			const client = new EvolvMock(keys);
 			new EvolvAssetManager(client, undefined, mockTiming());

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -808,4 +808,76 @@ describe('asset manager handles correctly', () => {
 			});
 		});
 	});
+
+	describe('Handle redirect variants', () => {
+		let origWindow;
+
+		beforeEach(function() {
+			origWindow = global.window;
+		});
+
+		afterEach(function() {
+			global.window = origWindow;
+		});
+
+		let keys = ['web.page1.redirectToGoogle'];
+		it('should redirect to google.com',async () => {
+			global.window = { location: { href: 'https://test-site.com' }, evolv: {}, confirm: () => true};
+			global.document = new DocumentMock();
+			const client = new EvolvMock(keys);
+			new EvolvAssetManager(client, undefined, mockTiming());
+			await wait(0);
+			assert.equal(window.location, 'https://google.com')
+		});
+
+		it('should handle 2 redirects and transfer user to the first url',async () => {
+			keys = ['web.page1.redirectToGoogle', 'web.page1.redirectToEvolv'];
+			global.window = { location: { href: 'https://test-site.com' }, evolv: {}, confirm: () => true};
+			global.document = new DocumentMock();
+			const client = new EvolvMock(keys);
+			new EvolvAssetManager(client, undefined, mockTiming());
+			await wait(0);
+			assert.equal(window.location, 'https://google.com')
+		});
+
+		it('shouldn\'t redirect if no redirect variants ',async () => {
+			keys = ['web.page1', 'web.page1.variable1'];
+			global.window = { location: { href: 'https://test-site.com' }, evolv: {}, confirm: () => true};
+			global.document = new DocumentMock();
+			const client = new EvolvMock(keys);
+			new EvolvAssetManager(client, undefined, mockTiming());
+			await wait(0);
+			assert.equal(window.location.href, 'https://test-site.com')
+		});
+
+		it('should handle partial path and  redirect to /goods',async () => {
+			keys = ['web.page1.redirectPartialPath'];
+			global.window = { location: { href: 'https://test-site.com', origin : 'https://test-site.com' }, evolv: {}, confirm: () => true};
+			global.document = new DocumentMock();
+			const client = new EvolvMock(keys);
+			new EvolvAssetManager(client, undefined, mockTiming());
+			await wait(0);
+			assert.equal(window.location, 'https://test-site.com/goods')
+		});
+
+		it('should handle partial path with params and redirect to /goods?qwerty=123',async () => {
+			keys = ['web.page1.redirectPartialPathWithParams'];
+			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com', search: '?qwerty=123' }, evolv: {}, confirm: () => true};
+			global.document = new DocumentMock();
+			const client = new EvolvMock(keys);
+			new EvolvAssetManager(client, undefined, mockTiming());
+			await wait(0);
+			assert.equal(window.location, 'https://test-site.com/goods?qwerty=123')
+		});
+
+		it('should handle redirect with params and redirect to /evolv.ai/?qwerty=123',async () => {
+			keys = ['web.page1.redirectWithParams'];
+			global.window = { location: { href: 'https://test-site.com/?qwerty=123', origin : 'https://test-site.com/', search: '?qwerty=123' }, evolv: {}, confirm: () => true};
+			global.document = new DocumentMock();
+			const client = new EvolvMock(keys);
+			new EvolvAssetManager(client, undefined, mockTiming());
+			await wait(0);
+			assert.equal(window.location, 'https://evolv.ai/?qwerty=123')
+		});
+	});
 });

--- a/src/tests/mocks/evolv.mock.js
+++ b/src/tests/mocks/evolv.mock.js
@@ -48,8 +48,43 @@ class EvolvMock {
 	}
 	on(){}
 
-	get(){
-		return new Promise(() =>null);
+	get(key){
+		if(key === 'web.page1.redirectToGoogle'){
+			return new Promise((resolve) => (resolve({
+				type: 'redirect',
+				target_url: 'https://google.com',
+				include_query_parameters: false
+			})));
+		}
+		if(key === 'web.page1.redirectToEvolv'){
+			return new Promise((resolve) => (resolve({
+				type: 'redirect',
+				target_url: 'https://evolv.ai',
+				include_query_parameters: false
+			})));
+		}
+		if(key === 'web.page1.redirectPartialPath'){
+			return new Promise((resolve) => (resolve({
+				type: 'redirect',
+				target_url: '/goods',
+				include_query_parameters: false
+			})));
+		}
+		if(key === 'web.page1.redirectPartialPathWithParams'){
+			return new Promise((resolve) => (resolve({
+				type: 'redirect',
+				target_url: '/goods',
+				include_query_parameters: true
+			})));
+		}
+		if(key === 'web.page1.redirectWithParams'){
+			return new Promise((resolve) => (resolve({
+				type: 'redirect',
+				target_url: 'https://evolv.ai/',
+				include_query_parameters: true
+			})));
+		}
+		return new Promise((_, reject) => reject(null));
 	}
 }
 

--- a/src/tests/mocks/evolv.mock.js
+++ b/src/tests/mocks/evolv.mock.js
@@ -1,3 +1,26 @@
+const keysDict = {
+	'web.page1.redirectToGoogle': {
+		target_url: 'https://google.com',
+		include_query_parameters: false
+	},
+	'web.page1.redirectToEvolv': {
+		target_url: 'https://evolv.ai',
+		include_query_parameters: false
+	},
+	'web.page1.redirectPartialPath': {
+		target_url: '/goods',
+		include_query_parameters: false
+	},
+	'web.page1.redirectPartialPathWithParams': {
+		target_url: '/goods',
+		include_query_parameters: true
+	},
+	'web.page1.redirectWithParams': {
+		target_url: 'https://evolv.ai/',
+		include_query_parameters: true
+	}
+}
+
 class EvolvMock {
 	constructor(keys = []) {
 		this.confirmations = 0;
@@ -49,39 +72,10 @@ class EvolvMock {
 	on(){}
 
 	get(key){
-		if(key === 'web.page1.redirectToGoogle'){
+		if(keysDict[key]){
 			return new Promise((resolve) => (resolve({
 				type: 'redirect',
-				target_url: 'https://google.com',
-				include_query_parameters: false
-			})));
-		}
-		if(key === 'web.page1.redirectToEvolv'){
-			return new Promise((resolve) => (resolve({
-				type: 'redirect',
-				target_url: 'https://evolv.ai',
-				include_query_parameters: false
-			})));
-		}
-		if(key === 'web.page1.redirectPartialPath'){
-			return new Promise((resolve) => (resolve({
-				type: 'redirect',
-				target_url: '/goods',
-				include_query_parameters: false
-			})));
-		}
-		if(key === 'web.page1.redirectPartialPathWithParams'){
-			return new Promise((resolve) => (resolve({
-				type: 'redirect',
-				target_url: '/goods',
-				include_query_parameters: true
-			})));
-		}
-		if(key === 'web.page1.redirectWithParams'){
-			return new Promise((resolve) => (resolve({
-				type: 'redirect',
-				target_url: 'https://evolv.ai/',
-				include_query_parameters: true
+				...keysDict[key]
 			})));
 		}
 		return new Promise((_, reject) => reject(null));

--- a/src/tests/mocks/evolv.mock.js
+++ b/src/tests/mocks/evolv.mock.js
@@ -23,10 +23,6 @@ const keysDict = {
 		target_url: 'http://info.cern.ch/',
 		include_query_parameters: false
 	},
-	'web.page1.redirectGoogleWithoutHttp': {
-		target_url: 'google.com',
-		include_query_parameters: false
-	}
 }
 
 class EvolvMock {

--- a/src/tests/mocks/evolv.mock.js
+++ b/src/tests/mocks/evolv.mock.js
@@ -18,6 +18,14 @@ const keysDict = {
 	'web.page1.redirectWithParams': {
 		target_url: 'https://evolv.ai/',
 		include_query_parameters: true
+	},
+	'web.page1.redirectToHttp': {
+		target_url: 'http://info.cern.ch/',
+		include_query_parameters: false
+	},
+	'web.page1.redirectGoogleWithoutHttp': {
+		target_url: 'google.com',
+		include_query_parameters: false
 	}
 }
 

--- a/src/tests/mocks/evolv.mock.js
+++ b/src/tests/mocks/evolv.mock.js
@@ -47,6 +47,10 @@ class EvolvMock {
 		this.keys = keys;
 	}
 	on(){}
+
+	get(){
+		return new Promise(() =>null);
+	}
 }
 
 class EvolvContextMock {

--- a/src/tests/mocks/evolv.mock.js
+++ b/src/tests/mocks/evolv.mock.js
@@ -47,6 +47,9 @@ class EvolvMock {
 
 	confirm() {
 		this.confirmations++;
+		return new Promise(function(resolve){
+			resolve();
+		})
 	}
 
 	contaminate() {


### PR DESCRIPTION
Handle redirect variant on asset-manager.
[AP-1986](https://evolv-ai.atlassian.net/browse/AP-1986)

Changes:
- Process redirect variants in asset-manager.js file
- Before processing redirect check if current url is not the same as url for redirecting
- Send confirmation before processing redirect
- handle redirect for all keys (not only web ones)


- Add tests for redirect variants

Testing:
Tested by running asset manager locally and linking it to the codesandbox website



https://user-images.githubusercontent.com/95315222/211435674-eaafa1d4-f2e2-4ea8-96a9-d38c990b4acd.mov


We send confirmation before redirecting:


https://user-images.githubusercontent.com/95315222/213012828-6b355328-d918-4809-8fd3-8f4b832177f4.mov


Handle redirect with promise:
https://user-images.githubusercontent.com/95315222/213321817-a0ce7f7d-89d0-4846-a451-94a7de48f4c0.mov



[AP-1986]: https://evolv-ai.atlassian.net/browse/AP-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ