### PR TITLE
AP-2274: fix redirect when new keys has arrived later

### DIFF
--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -59,7 +59,6 @@ function main(container, _runner) {
 		client.reevaluateContext();
 	};
 
-	let hasRunRedirect = false
 	let redirectionInProgress = false
 
 	client.getActiveKeys('web').listen(function (keys) {
@@ -89,27 +88,27 @@ function main(container, _runner) {
 	});
 
 	function runRedirectVariants(keys){
-		if(!hasRunRedirect){
-			hasRunRedirect = true
-			keys.current.forEach(function(key) {
-				client.get(key).then(function(v) {
-					if (redirectionInProgress || v.type !== 'redirect' || !v.target_url) {
-						return;
+		keys.current.forEach(function(key) {
+			client.get(key).then(function(v) {
+				if (redirectionInProgress || v.type !== 'redirect' || !v.target_url) {
+					return;
+				}
+				redirectionInProgress = true;
+				client.confirm()
+				.then(function() {
+					const params = v.include_query_parameters ? window.location.search : '';
+					const path = v.target_url + params;
+					const newUrl = new URL(path, window.location.href);
+					// Checking that url where we want to redirect the user is not the same as current url
+					if(newUrl.href !== window.location.href){
+						window.location = path;
 					}
-					client.confirm().then(function() {
-						// Target url can be a partial path, like '/products'. We should process it by adding it to the location.origin
-						const params = v.include_query_parameters ? window.location.search : '';
-						const path = v.target_url + params;
-						const newUrl = new URL(path, window.location.href);
-						// Checking that url where we want to redirect the user is not the same as current url
-						if(newUrl.href !== window.location.href){
-							window.location = path;
-							redirectionInProgress = true;
-						}
-					})
-				});
+				})
+				.catch(function() {
+					redirectionInProgress = false;
+				})
 			});
-		}
+		});
 	}
 }
 


### PR DESCRIPTION
[AP-2274](https://evolv-ai.atlassian.net/browse/AP-2274)
Issue:
Fixing the issue when redirect was not working. 
It is possible that the keys for redirect is added to the `activeKeys` later on . 

Solution:
Let runRedirectVariants function run as much as it needs in order to handle the keys that is added later.

[AP-2274]: https://evolv-ai.atlassian.net/browse/AP-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



https://user-images.githubusercontent.com/95315222/216442434-4ab11329-67a6-4a2d-89da-78d290e17a08.mov


