### PR TITLE
fix: some sites remove our css file

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -7,7 +7,7 @@ import { modes } from './modes/index.js';
 import { objectAssign } from './shims/object-assign.js';
 import firedEventsInitialization from './fired-events.js';
 import { injectScript } from './utils/inject-script.js'
-import { injectStylesheet } from './utils/inject-stylesheet.js'
+import { injectStylesheetWithAutoReplace } from './utils/inject-stylesheet.js'
 import { addEngagementEmitter } from './engagement.js'
 
 
@@ -207,7 +207,7 @@ export function bootstrap(initialConfig) {
 		});
 
 	if (css) {
-		injectStylesheet(endpoint, env, version, uid, previewCid);
+		injectStylesheetWithAutoReplace(endpoint, env, version, uid, previewCid);
 	}
 
 	let client = evolv.client;

--- a/src/utils/inject-stylesheet.js
+++ b/src/utils/inject-stylesheet.js
@@ -1,3 +1,42 @@
+export const MAX_RETRIES = 3;
+const MAX_REPLACE_TIME = 10000;
+
+/**
+ * @param {string} endpoint
+ * @param {string} env
+ * @param {number} version
+ * @param {string} uid
+ * @param {string} [cid]
+ *
+ * @returns {void}
+ */
+export function injectStylesheetWithAutoReplace(endpoint, env, version, uid, cid, attempt = 0) {
+	injectStylesheet(endpoint, env, version, uid, cid)
+	const url = getStyleSheetUrl(endpoint, env, version, uid, cid);
+	const cssFile = getCSSFile(url);
+
+	if (cssFile && window.MutationObserver) {
+		const observer = new window.MutationObserver(function (mutationList) {
+			mutationList.forEach(function (mutation) {
+				mutation.removedNodes.forEach(function (node) {
+					if (node.nodeName === 'LINK' && node.href === url && attempt < MAX_RETRIES) {
+						console.warn('Evolv AI: CSS removed, re-adding');
+						observer.disconnect();
+						injectStylesheetWithAutoReplace(endpoint, env, version, uid, cid, attempt + 1);
+					}
+				});
+			});
+		});
+		observer.observe(getCSSFile(url).parentNode, {
+			childList: true
+		});
+
+		setTimeout(function () {
+			observer.disconnect();
+		}, MAX_REPLACE_TIME);
+	}
+}
+
 /**
  * @param {string} endpoint
  * @param {string} env
@@ -8,12 +47,19 @@
  * @returns {void}
  */
 export function injectStylesheet(endpoint, env, version, uid, cid) {
-	const queryParams = (cid) ? '?previewcid=' + cid : '';
-
 	const stylesheet = document.createElement('link');
 	stylesheet.setAttribute('rel', 'stylesheet');
 	stylesheet.setAttribute('type', 'text/css');
-	stylesheet.setAttribute('href', endpoint.replace(/\/$/, '') + '/v' + version + '/' + env + '/' + uid + '/assets.css' + queryParams);
+	stylesheet.setAttribute('href', getStyleSheetUrl(endpoint, env, version, uid, cid));
 
 	document.head.appendChild(stylesheet);
+}
+
+function getStyleSheetUrl(endpoint, env, version, uid, cid) {
+	const queryParams = (cid) ? '?previewcid=' + cid : '';
+	return endpoint.replace(/\/$/, '') + '/v' + version + '/' + env + '/' + uid + '/assets.css' + queryParams;
+}
+
+function getCSSFile(url) {
+	return document.querySelector('link[href="' + url + '"]')
 }

--- a/src/utils/inject-stylesheet.js
+++ b/src/utils/inject-stylesheet.js
@@ -1,6 +1,7 @@
 export const MAX_RETRIES = 3;
 const MAX_REPLACE_TIME = 10000;
 
+// Some React sites will remove the stylesheet from the DOM, so we need to re-insert it
 /**
  * @param {string} endpoint
  * @param {string} env

--- a/src/utils/inject-stylesheet.js
+++ b/src/utils/inject-stylesheet.js
@@ -28,7 +28,7 @@ export function injectStylesheetWithAutoReplace(endpoint, env, version, uid, cid
 						injectStylesheetWithAutoReplace(endpoint, env, version, uid, cid, attempt + 1);
 					}
 
-					if (attempt === MAX_RETRIES) {
+					if (node.nodeName === 'LINK' && node.href === url && attempt === MAX_RETRIES) {
 						console.warn('Evolv AI: re-added CSS the maximum number of times');
 					}
 				});

--- a/src/utils/inject-stylesheet.js
+++ b/src/utils/inject-stylesheet.js
@@ -29,7 +29,7 @@ export function injectStylesheetWithAutoReplace(endpoint, env, version, uid, cid
 					}
 
 					if (attempt === MAX_RETRIES) {
-						console.warn('Evolv AI: re-adding CSS the maximum number of times');
+						console.warn('Evolv AI: re-added CSS the maximum number of times');
 					}
 				});
 			});

--- a/src/utils/inject-stylesheet.js
+++ b/src/utils/inject-stylesheet.js
@@ -18,12 +18,18 @@ export function injectStylesheetWithAutoReplace(endpoint, env, version, uid, cid
 
 	if (cssFile && window.MutationObserver) {
 		const observer = new window.MutationObserver(function (mutationList) {
+			let replaced = false;
 			mutationList.forEach(function (mutation) {
 				mutation.removedNodes.forEach(function (node) {
-					if (node.nodeName === 'LINK' && node.href === url && attempt < MAX_RETRIES) {
+					if (node.nodeName === 'LINK' && node.href === url && attempt < MAX_RETRIES && !replaced) {
 						console.warn('Evolv AI: CSS removed, re-adding');
 						observer.disconnect();
+						replaced = true;
 						injectStylesheetWithAutoReplace(endpoint, env, version, uid, cid, attempt + 1);
+					}
+
+					if (attempt === MAX_RETRIES) {
+						console.warn('Evolv AI: re-adding CSS the maximum number of times');
 					}
 				});
 			});

--- a/src/utils/tests/inject-stylesheet.test.js
+++ b/src/utils/tests/inject-stylesheet.test.js
@@ -42,9 +42,9 @@ describe('injectStylesheet()', () => {
 	});
 
 	afterEach(() => {
+		window.MutationObserver = originalMutationObserver;
 		cleanup();
 		callbacks = {};
-		window.MutationObserver = originalMutationObserver;
 	});
 
 	let assetsCSSUrl = 'https://participants.evolv.ai/v1/66c5421c67/97039403_1640028197170/assets.css';

--- a/src/utils/tests/inject-stylesheet.test.js
+++ b/src/utils/tests/inject-stylesheet.test.js
@@ -19,10 +19,12 @@ describe('injectStylesheet()', () => {
 	};
 
 	let callbacks = {}
+	let originalMutationObserver;
 
 	beforeEach(() => {
 		cleanup = jsdom();
 
+		originalMutationObserver = window.MutationObserver;
 		const mutationObserverMock = class MU {
 			_id = Math.random();
 			callback = null;
@@ -42,6 +44,7 @@ describe('injectStylesheet()', () => {
 	afterEach(() => {
 		cleanup();
 		callbacks = {};
+		window.MutationObserver = originalMutationObserver;
 	});
 
 	let assetsCSSUrl = 'https://participants.evolv.ai/v1/66c5421c67/97039403_1640028197170/assets.css';

--- a/src/utils/tests/inject-stylesheet.test.js
+++ b/src/utils/tests/inject-stylesheet.test.js
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 
 import jsdom from '../../tests/mocks/jsdom.js';
-import { injectStylesheet } from '../inject-stylesheet.js';
+import {injectStylesheet, injectStylesheetWithAutoReplace, MAX_RETRIES} from '../inject-stylesheet.js';
 
 
 describe('injectStylesheet()', () => {
@@ -12,14 +12,39 @@ describe('injectStylesheet()', () => {
 	const env = '66c5421c67';
 	const uid = '97039403_1640028197170';
 
+	const triggerCallback = (mockedMutationsList) => {
+		Object.entries(callbacks).forEach(([id, callback]) => {
+			callback(mockedMutationsList);
+		});
+	};
+
+	let callbacks = {}
+
 	beforeEach(() => {
 		cleanup = jsdom();
+
+		const mutationObserverMock = class MU {
+			_id = Math.random();
+			callback = null;
+			constructor(callback) {
+				this.callback = callback;
+			}
+			observe = () => {
+				callbacks[this._id] = this.callback;
+			};
+			disconnect = () => {
+				delete callbacks[this._id];
+			};
+		};
+		window.MutationObserver = mutationObserverMock;
 	});
 
 	afterEach(() => {
 		cleanup();
+		callbacks = {};
 	});
 
+	let assetsCSSUrl = 'https://participants.evolv.ai/v1/66c5421c67/97039403_1640028197170/assets.css';
 	it('should insert stylesheet into <head>', () => {
 		// Preconditions
 		assert.strictEqual(document.head.children.length, 0);
@@ -34,7 +59,7 @@ describe('injectStylesheet()', () => {
 
 		assert.strictEqual(tag.nodeName, 'LINK');
 		assert.strictEqual(tag.getAttribute('rel'), 'stylesheet');
-		assert.strictEqual(tag.getAttribute('href'), 'https://participants.evolv.ai/v1/66c5421c67/97039403_1640028197170/assets.css');
+		assert.strictEqual(tag.getAttribute('href'), assetsCSSUrl);
 	});
 
 	it('should append query string when `cid` argument is passed', () => {
@@ -57,5 +82,55 @@ describe('injectStylesheet()', () => {
 		assert.strictEqual(tag.getAttribute('href'), 'https://participants.evolv.ai/v1/66c5421c67/97039403_1640028197170/assets.css?previewcid=0a6990bda639:0af418c62e');
 		assert.strictEqual(url.searchParams.has('previewcid'), true);
 		assert.strictEqual(url.searchParams.get('previewcid'), '0a6990bda639:0af418c62e');
+	});
+
+	it('should reinsert stylesheet into <head> if it is removed by external task', () => {
+		// Preconditions
+		assert.strictEqual(document.head.children.length, 0);
+
+		// Act
+		injectStylesheetWithAutoReplace(endpoint, env, version, uid);
+
+		// Assert
+		assert.notStrictEqual(document.head.lastChild, null);
+
+		document.head.lastChild.remove();
+		triggerCallback([{
+			removedNodes: [{
+				nodeName: 'LINK',
+				href: assetsCSSUrl
+			}]
+		}]);
+
+		const tag = document.querySelector(`link[href="${assetsCSSUrl}"]`)
+
+		assert.notStrictEqual(document.head.lastChild, null);
+		assert.strictEqual(document.head.lastChild, tag);
+		assert.strictEqual(tag.nodeName, 'LINK');
+		assert.strictEqual(tag.getAttribute('rel'), 'stylesheet');
+		assert.strictEqual(tag.getAttribute('href'), assetsCSSUrl);
+	});
+
+	it('should reinsert stylesheet into <head> if it is removed by external task up to the max retries', () => {
+		// Preconditions
+		assert.strictEqual(document.head.children.length, 0);
+
+		// Act
+		injectStylesheetWithAutoReplace(endpoint, env, version, uid);
+
+		// Assert
+		assert.notStrictEqual(document.head.lastChild, null);
+
+		for (let i = 0; i <= MAX_RETRIES; i++) {
+			document.head.lastChild.remove();
+			triggerCallback([{
+				removedNodes: [{
+					nodeName: 'LINK',
+					href: assetsCSSUrl
+				}]
+			}]);
+		}
+
+		assert.strictEqual(document.head.lastChild, null);
 	});
 });


### PR DESCRIPTION
it looks timing related - as it doesn't happen if we load a little later. Likely React wiping the dom of changes

This change adds a mutation observer to the parent of the css file. then removes it after 10s

AP-2244