### PR TITLE
fix: add a dataset attribute for js load

### DIFF
--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -45,6 +45,11 @@ function main(container, _runner) {
 	const cssAsset = retrieveEvolvCssAsset(environment);
 	const jsAsset = retrieveEvolvJsAsset(environment);
 
+	const markDOMJSState = function (state) {
+		document.documentElement.dataset.evolvJs = state;
+	}
+	markDOMJSState(jsAsset ? 'loaded' : 'not-requested');
+
 	const runner = _runner || new Runner(container);
 
 	/**

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -183,7 +183,7 @@ describe('asset manager handles correctly', () => {
 				global.document = new DocumentMock({ elements: styleSheets, styleSheets });
 				const client = new EvolvMock();
 				new EvolvAssetManager(client, undefined, mockTiming());
-				assert.equal(document.classList.classList.length, 0)
+				assert.equal(document.classList.classList.length, 0);
 			});
 
 			it('for just stylesheets - will still confirm - but there is nothing to confirm into', () => {
@@ -192,6 +192,9 @@ describe('asset manager handles correctly', () => {
 				new EvolvAssetManager(client, undefined, mockTiming());
 				assert.equal(client.confirmations, 1);
 				assert.equal(client.contaminations, 0);
+
+				// verify we mark the status of the assets js load
+				assert.strictEqual(document.documentElement.dataset.evolvJs, 'not-requested');
 			});
 
 			it('for just javascript - will still confirm - but there is nothing to confirm into', () => {
@@ -203,6 +206,9 @@ describe('asset manager handles correctly', () => {
 				assert.equal(true, _mockRunner.updateFunctionsToRun.calledOnce);
 				assert.deepStrictEqual([], _mockRunner.updateFunctionsToRun.getCall(0).args[0]);
 				assert.equal(client.contaminations, 0);
+
+				// verify we mark the status of the assets js load
+				assert.strictEqual(document.documentElement.dataset.evolvJs, 'loaded');
 			});
 		});
 

--- a/src/tests/mocks/document.mock.js
+++ b/src/tests/mocks/document.mock.js
@@ -77,7 +77,8 @@ class DocumentMock {
 		this.scripts = options.scripts || [];
 		this.currentScript = options.currentScript;
 		this.documentElement = {
-			classList: this.classList
+			classList: this.classList,
+			dataset: {}
 		}
 		this.children = [];
 		this.head = {};

--- a/src/tests/webloader.test.js
+++ b/src/tests/webloader.test.js
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { WindowMock, DocumentMock, MOCK_GA_CLIENT_ID } from './mocks/document.mock.js';
+import { WindowMock, DocumentMock } from './mocks/document.mock.js';
 import EvolvMock from './mocks/evolv.mock.js';
 import sinon from 'sinon';
 
@@ -166,7 +166,7 @@ describe('the web loader', () => {
 			assert.strictEqual(window.evolv.client.environment, queryEnvironmentId, 'Environment id should be overridden');
 		});
 
-		it('should use the environment data parameter if set and not thefirst  query param', async () => {
+		it('should use the environment data parameter if set and not the first  query param', async () => {
 			setupGlobal(null, undefined, {
 				evolvEnvironment: undefined
 			});


### PR DESCRIPTION
this will allow web editor to read if the assets js has been loaded/doesn't need to be

This is required to allow us to wait until integrations have run

AP-3414