### PR TITLE
fix: allow dom capture data tags

### DIFF
--- a/src/build-config.js
+++ b/src/build-config.js
@@ -51,6 +51,7 @@ export function buildConfig(dataset) {
 	for (let prop in dataset) {
 		const name = stripPrefix(prop);
 
+
 		switch (prop) {
 			case 'evolvLazyUid':
 			case 'evolvRequireConsent':
@@ -69,25 +70,15 @@ export function buildConfig(dataset) {
 				break;
 			}
 			case 'evolvCapture': {
-				const stringValue = dataset[prop];
-				if (!stringValue) {
-					config[name] = undefined;
-					break;
-				}
-
-				const booleanString = stringValue.toLowerCase();
-				if (booleanString === 'true') {
-					config[name] = 1;
-					break;
-				} else if (booleanString === 'false') {
-					config[name] = undefined;
-					break;
-				}
-
+				const stringValue = (dataset[prop] || '').toLowerCase();
 				const numberValue = +stringValue;
-				config[name] = isNaN(numberValue)
-					? undefined
-					: numberValue;
+				if (stringValue === 'true') {
+					config[name] = 1;
+				} else if (!isNaN(numberValue)) {
+					config[name] = numberValue;
+				} else {
+					config[name] = undefined;
+				}
 				break;
 			}
 			case 'evolvUseCookies':

--- a/src/build-config.js
+++ b/src/build-config.js
@@ -81,6 +81,7 @@ export function buildConfig(dataset) {
 					break;
 				} else if (booleanString === 'false') {
 					config[name] = 0;
+					break;
 				}
 
 				const numberValue = +stringValue;

--- a/src/build-config.js
+++ b/src/build-config.js
@@ -68,6 +68,27 @@ export function buildConfig(dataset) {
 					: value;
 				break;
 			}
+			case 'evolvCapture': {
+				const stringValue = dataset[prop];
+				if (!stringValue) {
+					config[name] = undefined;
+					break;
+				}
+
+				const booleanString = stringValue.toLowerCase();
+				if (booleanString === 'true') {
+					config[name] = 1;
+					break;
+				} else if (booleanString === 'false') {
+					config[name] = 0;
+				}
+
+				const numberValue = +stringValue;
+				config[name] = isNaN(numberValue)
+					? undefined
+					: numberValue;
+				break;
+			}
 			case 'evolvUseCookies':
 			default: {
 				config[name] = dataset[prop];

--- a/src/build-config.js
+++ b/src/build-config.js
@@ -80,7 +80,7 @@ export function buildConfig(dataset) {
 					config[name] = 1;
 					break;
 				} else if (booleanString === 'false') {
-					config[name] = 0;
+					config[name] = undefined;
 					break;
 				}
 

--- a/src/tests/build-config.test.js
+++ b/src/tests/build-config.test.js
@@ -116,7 +116,7 @@ describe('buildConfig()', () => {
 			assert.strictEqual(config.capture, 1);
 		});
 
-		it('capture value should be 0 when false', () => {
+		it('capture value should be undefined when false', () => {
 			// Arrange
 			const script = document.createElement('script');
 			document.body.appendChild(script);
@@ -126,7 +126,7 @@ describe('buildConfig()', () => {
 			const config = buildConfig(script.dataset);
 
 			// Assert
-			assert.strictEqual(config.capture, 0);
+			assert.strictEqual(config.capture, undefined);
 		});
 
 		it('capture value should be a number when set to a number', () => {

--- a/src/tests/build-config.test.js
+++ b/src/tests/build-config.test.js
@@ -89,4 +89,70 @@ describe('buildConfig()', () => {
 			assert.strictEqual(config.timeout, undefined);
 		});
 	});
+
+	describe('data-evolv-capture', () => {
+		it('capture value should be undefined when not set', () => {
+			// Arrange
+			const script = document.createElement('script');
+			document.body.appendChild(script);
+
+			// Act
+			const config = buildConfig(script.dataset);
+
+			// Assert
+			assert.strictEqual(config.capture, undefined);
+		});
+
+		it('capture value should be 1 when true', () => {
+			// Arrange
+			const script = document.createElement('script');
+			document.body.appendChild(script);
+			script.setAttribute('data-evolv-capture', 'true');
+
+			// Act
+			const config = buildConfig(script.dataset);
+
+			// Assert
+			assert.strictEqual(config.capture, 1);
+		});
+
+		it('capture value should be undefined when false', () => {
+			// Arrange
+			const script = document.createElement('script');
+			document.body.appendChild(script);
+			script.setAttribute('data-evolv-capture', 'false');
+
+			// Act
+			const config = buildConfig(script.dataset);
+
+			// Assert
+			assert.strictEqual(config.capture, undefined);
+		});
+
+		it('capture value should be a number when set to a number', () => {
+			// Arrange
+			const script = document.createElement('script');
+			document.body.appendChild(script);
+			script.setAttribute('data-evolv-capture', '17.8');
+
+			// Act
+			const config = buildConfig(script.dataset);
+
+			// Assert
+			assert.strictEqual(config.capture, 17.8);
+		});
+
+		it('capture value should be undefined when set to a garbage string', () => {
+			// Arrange
+			const script = document.createElement('script');
+			document.body.appendChild(script);
+			script.setAttribute('data-evolv-capture', 'garbageString#$%^&*');
+
+			// Act
+			const config = buildConfig(script.dataset);
+
+			// Assert
+			assert.strictEqual(config.capture, undefined);
+		});
+	});
 });

--- a/src/tests/build-config.test.js
+++ b/src/tests/build-config.test.js
@@ -91,7 +91,7 @@ describe('buildConfig()', () => {
 	});
 
 	describe('data-evolv-capture', () => {
-		it('capture value should be undefined when not set', () => {
+		it('should be undefined when not set', () => {
 			// Arrange
 			const script = document.createElement('script');
 			document.body.appendChild(script);
@@ -103,7 +103,7 @@ describe('buildConfig()', () => {
 			assert.strictEqual(config.capture, undefined);
 		});
 
-		it('capture value should be 1 when true', () => {
+		it('should be 1 when true', () => {
 			// Arrange
 			const script = document.createElement('script');
 			document.body.appendChild(script);
@@ -116,7 +116,7 @@ describe('buildConfig()', () => {
 			assert.strictEqual(config.capture, 1);
 		});
 
-		it('capture value should be undefined when false', () => {
+		it('should be undefined when false', () => {
 			// Arrange
 			const script = document.createElement('script');
 			document.body.appendChild(script);
@@ -129,7 +129,7 @@ describe('buildConfig()', () => {
 			assert.strictEqual(config.capture, undefined);
 		});
 
-		it('capture value should be a number when set to a number', () => {
+		it('should be a number when set to a number', () => {
 			// Arrange
 			const script = document.createElement('script');
 			document.body.appendChild(script);
@@ -142,7 +142,7 @@ describe('buildConfig()', () => {
 			assert.strictEqual(config.capture, 17.8);
 		});
 
-		it('capture value should be undefined when set to a garbage string', () => {
+		it('should be undefined when set to a garbage string', () => {
 			// Arrange
 			const script = document.createElement('script');
 			document.body.appendChild(script);

--- a/src/tests/build-config.test.js
+++ b/src/tests/build-config.test.js
@@ -116,7 +116,7 @@ describe('buildConfig()', () => {
 			assert.strictEqual(config.capture, 1);
 		});
 
-		it('capture value should be undefined when false', () => {
+		it('capture value should be 0 when false', () => {
 			// Arrange
 			const script = document.createElement('script');
 			document.body.appendChild(script);
@@ -126,7 +126,7 @@ describe('buildConfig()', () => {
 			const config = buildConfig(script.dataset);
 
 			// Assert
-			assert.strictEqual(config.capture, undefined);
+			assert.strictEqual(config.capture, 0);
 		});
 
 		it('capture value should be a number when set to a number', () => {


### PR DESCRIPTION
The config value must be a boolean or a number. Currently it's just interpreted as a string, which won't function properly