### PR TITLE
fix: Mock the data and events request

### DIFF
--- a/e2e/helpers/build-request-hooks.ts
+++ b/e2e/helpers/build-request-hooks.ts
@@ -38,6 +38,18 @@ export function buildRequestHooks(fixtures: RequestFixtures) {
 			.respond(fixtures.allocations, 200, {
 				...headers,
 				'content-type': 'application/json'
+			}),
+		RequestMock()
+			.onRequestTo(/participants\.evolv\.ai\/v1\/.*\/data/)
+			.respond('', 200, {
+				...headers,
+				'content-type': 'text/plain;charset=UTF-8'
+			}),
+		RequestMock()
+			.onRequestTo(/participants\.evolv\.ai\/v1\/.*\/events/)
+			.respond('', 200, {
+				...headers,
+				'content-type': 'text/plain;charset=UTF-8'
 			})
 	]
 }


### PR DESCRIPTION
So we don't pick up the error from using GET requests and pointing at prod which does not support them