### PR TITLE
fix: webloader-capture typo

### DIFF
--- a/src/webloader-capture.js
+++ b/src/webloader-capture.js
@@ -9,6 +9,6 @@ initialize(function(config) {
 		capture: config.capture,
 		endpoint: config.captureEndpoint,
 		blockSelector: config.captureBlockSelector,
-		captureUserInteractions: config.captureUserInterations
+		captureUserInteractions: config.captureUserInteractions
 	});
 });


### PR DESCRIPTION
Makes it so that we don't have to write a typo in the snippet