### PR TITLE
fix(AP-3821): Prevent auto-confirmation when using previewCid

### DIFF
--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -1,4 +1,4 @@
-import { Runner } from './runner.js';
+import { checkPreviewCid, Runner } from './runner.js';
 import { toUnderscoreKey } from './utils.js';
 
 /**
@@ -82,7 +82,11 @@ function main(container, _runner) {
 		if (jsAsset) {
 			runner.updateFunctionsToRun(liveContexts);
 		} else if (cssAsset) {
-			confirm();
+			const hasPreviewCid = checkPreviewCid();
+
+			if (!hasPreviewCid) {
+				confirm();
+			}
 		}
 		runRedirectVariants(keys);
 	});

--- a/src/runner.js
+++ b/src/runner.js
@@ -49,7 +49,7 @@ const hasNotCompleted = function(def) {
 /**
  * @returns {boolean}
  */
-const checkPreviewCid = function() {
+export const checkPreviewCid = function() {
 	return window.sessionStorage && window.sessionStorage.getItem('evolv:previewCid') ? true : false;
 };
 
@@ -386,7 +386,7 @@ const Runner = /** @class */ (function () {
 	 * @private
 	 */
 	Runner.prototype.confirm = function () {
-			this.container.client.confirm();
+		this.container.client.confirm();
 	};
 
 	/**

--- a/src/runner.js
+++ b/src/runner.js
@@ -47,6 +47,13 @@ const hasNotCompleted = function(def) {
 };
 
 /**
+ * @returns {boolean}
+ */
+const checkPreviewCid = function() {
+	return window.sessionStorage && window.sessionStorage.getItem('evolv:previewCid') ? true : false;
+};
+
+/**
  * @enum {number}
  */
 const RunLevel = {
@@ -367,7 +374,9 @@ const Runner = /** @class */ (function () {
 				return ['resolved', 'not-runnable'].indexOf(def.status) !== -1;
 			});
 
-		if (allResolvedOrNotRunnable) {
+		const hasPreviewCid = checkPreviewCid();
+
+		if (allResolvedOrNotRunnable && !hasPreviewCid) {
 			this.confirm();
 		}
 	};
@@ -377,7 +386,7 @@ const Runner = /** @class */ (function () {
 	 * @private
 	 */
 	Runner.prototype.confirm = function () {
-		this.container.client.confirm();
+			this.container.client.confirm();
 	};
 
 	/**

--- a/src/tests/runner.test.js
+++ b/src/tests/runner.test.js
@@ -18,7 +18,9 @@ describe('Runner', () => {
 	let container;
 
 	beforeEach(() => {
-		cleanup = jsdom();
+		cleanup = jsdom(undefined, {
+			url: 'http://localhost/'
+		});
 
 		const client = new EvolvMock();
 		sandbox.spy(client);


### PR DESCRIPTION
Updated solution to not confirming when you have `evolv:previewCid` set in session storage.

This update checks for the storage item inside the `runner` that runs automatically when the webloader executes. It prevents confirmations when the item is found.

Because I only changed the runner, you can manually confirm into the project if you decide to by running `evolv.client.confirm()`. I think it's important to maintain that flexibility.