### PR TITLE
feat(AP-4079): Add debug data attribute

### DIFF
--- a/src/asset-manager.js
+++ b/src/asset-manager.js
@@ -6,6 +6,7 @@ import { toUnderscoreKey } from './utils.js';
  * @property {number} timeoutThreshold
  * @property {number} legacyPollingInterval
  * @property {Promise} scriptPromise
+ * @property {boolean} debug
  */
 
 /**

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -106,7 +106,8 @@ export const defaultConfig = {
 	js: true,
 	css: true,
 	pushstate: false,
-	timeout: undefined
+	timeout: undefined,
+	debug: false
 };
 
 /**
@@ -195,6 +196,7 @@ export function bootstrap(initialConfig) {
 	let css = !!candidateToken || config.css;
 	let pushstate = config.pushstate;
 	let endpoint = config.endpoint;
+	const debug = config.debug;
 
 	const uid = evolv.context
 		? evolv.context.uid
@@ -220,6 +222,7 @@ export function bootstrap(initialConfig) {
 
 	if (!client) {
 		let options = {
+			debug: debug,
 			environment: env,
 			endpoint: endpoint,
 			version: version,
@@ -263,7 +266,8 @@ export function bootstrap(initialConfig) {
 
 	const assetManager = new EvolvAssetManager(client, {
 		timeoutThreshold: config.timeout,
-		variantsLoaded: scriptPromise
+		variantsLoaded: scriptPromise,
+		debug: config.debug
 	});
 
 	Object.defineProperty(window.evolv, 'assetManager', {

--- a/src/build-config.js
+++ b/src/build-config.js
@@ -10,6 +10,7 @@
  * @property {string} [evolvCss]
  * @property {string} [evolvPushstate]
  * @property {string} [evolvTimeout]
+ * @property {string} [evolvDebug]
  */
 
 /**
@@ -24,6 +25,7 @@
  * @property {boolean} css
  * @property {boolean} pushstate
  * @property {number|undefined} timeout
+ * @property {boolean} debug
  */
 
 /**
@@ -53,6 +55,7 @@ export function buildConfig(dataset) {
 
 
 		switch (prop) {
+			case 'evolvDebug':
 			case 'evolvLazyUid':
 			case 'evolvRequireConsent':
 			case 'evolvJs':

--- a/src/runner.js
+++ b/src/runner.js
@@ -264,6 +264,7 @@ const Runner = /** @class */ (function () {
 	 */
 	Runner.prototype.execute = function () {
 		const client = this.container.client;
+		const options = this.container.options;
 
 		const runnableAtCurrentLevel = function (def) {
 			return levelMap[def.timing] <= this.runLevel;
@@ -305,10 +306,19 @@ const Runner = /** @class */ (function () {
 					const message = (err && err.message) ? err.message : '';
 
 					def.status = 'rejected';
-					client.contaminate({
-						reason: 'error-thrown',
-						details: message
-					});
+
+					if (options.debug) {
+						client.contaminate({
+							reason: 'error-thrown',
+							details: message,
+							stack: err.stack
+						});
+					} else {
+						client.contaminate({
+							reason: 'error-thrown',
+							details: message
+						});
+					}
 
 					console.warn('[Evolv]: An error occurred while applying a javascript mutation. ' + err);
 				})


### PR DESCRIPTION
[AP-4079](https://evolv-ai.atlassian.net/browse/AP-4079)

- Added `data-evolv-debug` attribute.

When set to `true`, all contaminations report a stack trace of the error.

[This test page](https://ne2ct.csb.app/page1.html) has experiment running with an error in the context.

```
<script
    src="webloader.js"
    data-evolv-endpoint="https://participants-stg.evolv.ai"
    data-evolv-environment="e6ac170eb9"
    data-evolv-debug="true"
  ></script>
```


[AP-4079]: https://evolv-ai.atlassian.net/browse/AP-4079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ