### PR TITLE
feat(AP-5739): Support query params for preview links

### DIFF
--- a/src/modes/preview.mode.js
+++ b/src/modes/preview.mode.js
@@ -1,18 +1,36 @@
 export const PREVIEW_REGEX = 'evolvPreviewCid=([0-9a-f]+(?:(?:%3a|:)[0-9a-f]+)+)';
-const PREVIEW_REGEX_REPLACE = '#?&?' + PREVIEW_REGEX;
+const PREVIEW_REGEX_HASH = '[#&]' + PREVIEW_REGEX;
+const PREVIEW_REGEX_SEARCH = '[?&]' + PREVIEW_REGEX;
 
 export default {
 	shouldActivate: function () {
-		return window.location.hash.match(new RegExp(PREVIEW_REGEX));
+		return window.location.hash.match(new RegExp(PREVIEW_REGEX_HASH)) || window.location.search.match(new RegExp(PREVIEW_REGEX_SEARCH));
 	},
 	activate: function () {
-		const match = window.location.hash.match(new RegExp(PREVIEW_REGEX));
+		const hashMatch = window.location.hash.match(new RegExp(PREVIEW_REGEX_HASH));
 
-		if (match) {
-			const token = match[1];
-
+		if (hashMatch) {
+			const token = hashMatch[1];
 			window.sessionStorage.setItem('evolv:previewCid', token);
-			window.location.href = window.location.href.replace(new RegExp(PREVIEW_REGEX_REPLACE), '');
+
+			const url = new URL(window.location.href);
+			const newHash = url.hash.replace(new RegExp(PREVIEW_REGEX_HASH), '');
+			url.hash = newHash.length > 0 ? '#' + newHash.slice(1) : '';
+			window.location.href = url.toString();
+
+			return;
+		}
+
+		const queryMatch = window.location.search.match(new RegExp(PREVIEW_REGEX_SEARCH));
+
+		if (queryMatch) {
+			const token = queryMatch[1];
+			window.sessionStorage.setItem('evolv:previewCid', token);
+
+			const url = new URL(window.location.href);
+			const newSearch = url.search.replace(new RegExp(PREVIEW_REGEX_SEARCH), '');
+			url.search = newSearch.length > 0 ? '?' + newSearch.slice(1) : '';
+			window.location.href = url.toString();
 		}
 	}
 };


### PR DESCRIPTION
[AP-5739]

bonus: fixes a bug where we would replace the leading "#" with a "?" if
there were multiple hash params and the preview one was first.


[AP-5739]: https://evolv-ai.atlassian.net/browse/AP-5739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ